### PR TITLE
add file to fix testing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
   imports:
     - cvxopt
   source_files:
-    - tests/*.py
+    - tests/*
     - examples/*
 
 about:


### PR DESCRIPTION
I'm guessing that defaults has dropped this package since it's not included in aggregates and the anaconda channel didn't build it for py37. So this PR can be ignored and only serve as a hint to get a successful build for anyone who uses this recipe to get a MKL and py37 cvxopt package. Built and tested cleanly on Linux/Mac py36/py37. This fix already in c-f upstream recipe.