### PR TITLE
cvxopt 1.3.0 (rebuild)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,7 +35,7 @@ export CVXOPT_DSDP_LIB_DIR="${PREFIX}/lib"
 export CVXOPT_DSDP_INC_DIR="${PREFIX}/include"
 
 export CVXOPT_SUITESPARSE_LIB_DIR="${PREFIX}/lib"
-export CVXOPT_SUITESPARSE_INC_DIR="${PREFIX}/include"
+export CVXOPT_SUITESPARSE_INC_DIR="${PREFIX}/include/suitesparse"
 
 export CFLAGS="${CFLAGS} -Wno-return-type"
 export CXXFLAGS="${CXXFLAGS} -Wno-return-type"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   build:
     - {{ stdlib("c") }}
     - {{ compiler("c") }}
-    - m2-patch  # [win]
+    - msys2-patch  # [win]
   host:
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.3.0" %}
-{% set suitesparse_for_win_version = "5.7.2" %}
+{% set suitesparse_for_win_version = "7.8.3" %}
 
 package:
   name: cvxopt
@@ -20,12 +20,11 @@ build:
   number: 0
   # mkl is incompatible with GPL
   skip: True  # [blas_impl == 'mkl']
-  # no suitesparse support on s390x
-  skip: true  # [s390x]
   ignore_run_exports:  # [win]
     - glpk             # [win]
 requirements:
   build:
+    - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - m2-patch  # [win]
   host:
@@ -37,16 +36,16 @@ requirements:
     - fftw 3.3.9
     - glpk 4.65
     - gsl 2.7.1
-    - openblas-devel {{ openblas }}  # [blas_impl == "openblas"]
+    - openblas-devel {{ openblas_devel }}  # [blas_impl == "openblas"]
     # suitesparse is linked against on windows, and compiled-in on windows, because yeah, windows.
-    - suitesparse 5.10.1            # [not win]
+    - suitesparse 7.8.3  # [not win]
   run:
     - python
     - gsl
     - fftw
     - dsdp
     - glpk
-    - suitesparse                    # [unix]
+    - suitesparse  # [unix]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ requirements:
 
 test:
   source_files:
+    # examples are required to run tests
     - tests/*
     - examples/*
   requires:
@@ -56,6 +57,7 @@ test:
     - pip
   commands:
     - pip check
+    - pytest -vv tests
 
 about:
   home: https://cvxopt.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,9 @@ requirements:
     - pip
     - wheel  
     - dsdp 5.8
-    - fftw 3.3.9
-    - glpk 4.65
-    - gsl 2.7.1
+    - fftw {{ fftw }}
+    - glpk {{ glpk }}
+    - gsl {{ gsl }}
     - openblas-devel {{ openblas_devel }}  # [blas_impl == "openblas"]
     # suitesparse is linked against on windows, and compiled-in on windows, because yeah, windows.
     - suitesparse {{ suitesparse }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - gsl 2.7.1
     - openblas-devel {{ openblas_devel }}  # [blas_impl == "openblas"]
     # suitesparse is linked against on windows, and compiled-in on windows, because yeah, windows.
-    - suitesparse 7.8.3  # [not win]
+    - suitesparse {{ suitesparse }}  # [not win]
   run:
     - python
     - gsl


### PR DESCRIPTION
cvxopt 1.3.0 

**Destination channel:** Defaults

### Links

- [PKG-8749]
- dev_url:        https://github.com/cvxopt/cvxopt
- conda_forge:    https://github.com/conda-forge/cvxopt-feedstock
- pypi:           https://pypi.org/project/cvxopt/1.3.0
- pypi inspector: https://inspector.pypi.io/project/cvxopt/1.3.0

### Explanation of changes:

- rebuild against suitesparse 7.8.3


[PKG-8749]: https://anaconda.atlassian.net/browse/PKG-8749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ