### PR TITLE
cvxopt 1.3.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.2" %}
+{% set version = "1.3.3" %}
 {% set name = "cvxopt" %}
 {% set suitesparse_for_win_version = "7.8.3" %}
 
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 3461fa42c1b2240ba4da1d985ca73503914157fc4c77417327ed6d7d85acdbe6
+    sha256: 8059cef41f1f115c87bc9b75fec9f86db95e7f0afcf03a52d619ba433e443bcb
   # on windows, building suitesparse in directly works much better than trying to build it separately and link it in
   {% if win %}
   - url: https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v{{ suitesparse_for_win_version }}.tar.gz
@@ -22,6 +22,7 @@ build:
   number: 0
   # mkl is incompatible with GPL
   skip: true  # [blas_impl == 'mkl']
+  skip: true  # [py<38]
   ignore_run_exports:  # [win]
     - glpk  # [win]
 
@@ -31,7 +32,8 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - setuptools >=45
+    - setuptools >=64
+    - setuptools-scm >=8
     - pip
     - dsdp 5.8
     - fftw {{ fftw }}
@@ -40,7 +42,6 @@ requirements:
     - openblas-devel {{ openblas_devel }}  # [blas_impl == "openblas"]
     # suitesparse is linked against on windows, and compiled-in on windows, because yeah, windows.
     - suitesparse {{ suitesparse }}  # [not win]
-    - setuptools-scm >=6.2
   run:
     - python
     - gsl


### PR DESCRIPTION
cvxopt 1.3.3 

**Destination channel:** Defaults

### Links

- [PKG-12448]
- dev_url:        https://github.com/cvxopt/cvxopt/tree/1.3.3
- conda_forge:    https://github.com/conda-forge/cvxopt-feedstock
- pypi:           https://pypi.org/project/cvxopt/1.3.3
- pypi inspector: https://inspector.pypi.io/project/cvxopt/1.3.3

### Explanation of changes:

- new version number


[PKG-12448]: https://anaconda.atlassian.net/browse/PKG-12448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ